### PR TITLE
feat: 뒤로가기(BackButton) 컴포넌트 구현

### DIFF
--- a/src/components/common/BackButton.vue
+++ b/src/components/common/BackButton.vue
@@ -1,0 +1,34 @@
+<template>
+  <button
+    @click="goBack"
+    class="trk-btn-back trk-bg-5 trk-text-1 my-2 mx-2 cursor-pointer"
+  >
+    <i class="fa-solid fa-arrow-left"></i>
+  </button>
+</template>
+
+<script setup>
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+
+const goBack = () => {
+  router.back();
+};
+</script>
+
+<style scoped>
+.trk-btn-back {
+  height: fit-content;
+  width: fit-content;
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem 2rem;
+  border-radius: 20px;
+}
+.trk-btn-back:hover {
+  opacity: 0.85;
+}
+</style>

--- a/src/components/common/uiTest.vue
+++ b/src/components/common/uiTest.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="p-4">
+    <BackButton />
     <h2>Confirm 컴포넌트 테스트</h2>
-
     <button
       class="trk-btn-confirm"
       @click="handleLogout"
@@ -13,6 +13,7 @@
 
 <script setup>
 import { inject } from "vue";
+import BackButton from "@/components/common/BackButton.vue";
 
 const alert = inject("useAlert");
 const confirm = inject("useConfirm");


### PR DESCRIPTION
## 📦 컴포넌트 설명
- BackButton.vue: 뒤로가기 기능을 수행하는 공통 버튼
- router.back() 기반으로 이전 페이지로 이동
- trk-btn-back 클래스 사용, 프로젝트 디자인 시스템 적용

## 🧪 테스트
- uiTest.vue 및 실제 페이지에서 뒤로 이동 확인

## 🧭 뒤로가기 버튼(BackButton.vue) 가이드

- 기본 버튼은 `fit-content`로 스타일링 되어 있음
- 원하는 위치에 `<BackButton />`을 자유롭게 배치해서 사용 가능

📍 왼쪽 상단 고정이 필요할 경우, 아래처럼 부모 요소에서 처리해주세요:

```html
<div style="position: relative;">
  <BackButton style="position: absolute; top: 1rem; left: 1rem;" />
</div>